### PR TITLE
Copy almost all types of files in resources

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -70,7 +70,9 @@ for DIR in resources
 do
     mkdir -p $OUTDIR/$DIR
 
-    for FILE in `ls $DIR/*.html $DIR/*.geojson $DIR/*.png $DIR/*.R $DIR/*.py`
+    # Copy all files with name and extension naming scheme.
+    # (Ignore anything which looks special, e.g., directories.)
+    for FILE in `ls $DIR/*.*`
     do
         cp $FILE $OUTDIR/$DIR
     done


### PR DESCRIPTION
Copy all except names which look special because they lack extension (e.g., Makefile won't get copied). Directories are copied separately.
