### PR TITLE
Update and generalize references to GRASS versions

### DIFF
--- a/assignments/abm.html
+++ b/assignments/abm.html
@@ -3,7 +3,7 @@
 <p>
 Resources:
 <ul>
-    <li><a href="http://grass.osgeo.org/grass-stable/manuals/index.html">
+    <li><a href="http://grass.osgeo.org/grass-stable/manuals/">
 GRASS GIS overview and manual</a>
     <li><a href="http://www.grassbook.org/">GRASS book</a>
     <li><a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.landscape.evol.html">r.landscape.evol</a>

--- a/assignments/abm.html
+++ b/assignments/abm.html
@@ -3,10 +3,10 @@
 <p>
 Resources:
 <ul>
-    <li><a href="http://grass.osgeo.org/grass74/manuals/index.html">
+    <li><a href="http://grass.osgeo.org/grass-stable/manuals/index.html">
 GRASS GIS overview and manual</a>
     <li><a href="http://www.grassbook.org/">GRASS book</a>
-    <li><a href="https://grass.osgeo.org/grass74/manuals/addons/r.landscape.evol.html">r.landscape.evol</a>
+    <li><a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.landscape.evol.html">r.landscape.evol</a>
     <li><a href="https://github.com/projectmesa/mesa/">MESA: agent based modeling in Python</a>
 </ul>
 

--- a/assignments/behavioral_mobility.html
+++ b/assignments/behavioral_mobility.html
@@ -14,7 +14,7 @@
 <h3>Software</h3>
 <ul>
     <li><a href="http://grass.osgeo.org/">GRASS GIS</a>
-    <li><a href="http://grass.osgeo.org/grass82/manuals/"> GRASS GIS overview and manual</a>
+    <li><a href="http://grass.osgeo.org/grass-stable/manuals/"> GRASS GIS overview and manual</a>
 </ul>
 
 <h3>Data</h3>
@@ -46,7 +46,7 @@ Netherlands provides standardized geospatial data through
 
 <p>
 Before starting it is useful to go through
-<a href="https://grass.osgeo.org/grass82/manuals/helptext.html">GRASS GIS Quickstart</a>
+<a href="https://grass.osgeo.org/grass-stable/manuals/helptext.html">GRASS GIS Quickstart</a>
 and  learn some GRASS GIS terminology for its data organization.
 
 <p>

--- a/assignments/behavioral_mobility.html
+++ b/assignments/behavioral_mobility.html
@@ -72,7 +72,7 @@ Move the <code>workshop_breda_external.zip</code> into your <code>giswork</code>
 Start GRASS - click on GRASS icon or type<br>
 
 <pre><code>
-grass82
+grass
 </code></pre>
 
 <p>

--- a/assignments/behavioral_mobility.html
+++ b/assignments/behavioral_mobility.html
@@ -14,7 +14,7 @@
 <h3>Software</h3>
 <ul>
     <li><a href="http://grass.osgeo.org/">GRASS GIS</a>
-    <li><a href="http://grass.osgeo.org/grass82/manuals/index.html"> GRASS GIS overview and manual</a>
+    <li><a href="http://grass.osgeo.org/grass82/manuals/"> GRASS GIS overview and manual</a>
 </ul>
 
 <h3>Data</h3>

--- a/assignments/data_sim_assign.html
+++ b/assignments/data_sim_assign.html
@@ -3,7 +3,7 @@
 <p>
 Resources:
 <ul>
-    <li><a href="http://grass.osgeo.org/grass74/manuals/index.html">
+    <li><a href="http://grass.osgeo.org/grass-stable/manuals/index.html">
 GRASS GIS overview and manual</a>
     <li><a href="http://www.grassbook.org/">GRASS book</a>
 </ul>

--- a/assignments/data_sim_assign.html
+++ b/assignments/data_sim_assign.html
@@ -3,7 +3,7 @@
 <p>
 Resources:
 <ul>
-    <li><a href="http://grass.osgeo.org/grass-stable/manuals/index.html">
+    <li><a href="http://grass.osgeo.org/grass-stable/manuals/">
 GRASS GIS overview and manual</a>
     <li><a href="http://www.grassbook.org/">GRASS book</a>
 </ul>

--- a/assignments/data_sim_assign.html
+++ b/assignments/data_sim_assign.html
@@ -259,7 +259,7 @@ r.random, r.random.cells, r.sample.category, v.perturb, v.random, v.kcv
 Create several landscape cover scenarios, for example, to explore the following scenario - 
 if we need to convert 30% of forest to development, is it better to create a single compact area
 or many smaller areas? Read the manual pages for
-<a href="https://grass.osgeo.org/grass80/manuals/addons/r.pi.html">r.pi </a> to understand 
+<a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.pi.html">r.pi </a> to understand
 what the commands perform and feel free to change the examples below to get more realistics results.
 
 <pre><code>

--- a/assignments/data_sim_assign.html
+++ b/assignments/data_sim_assign.html
@@ -21,7 +21,7 @@ instructions for the
 Start GRASS - click on GRASS icon or type<br>
 
 <pre><code>
-grass78
+grass
 </code></pre>
 
 <p>

--- a/assignments/grass_hpc_futures.html
+++ b/assignments/grass_hpc_futures.html
@@ -118,7 +118,7 @@ wait
 
 <h3>Computing development pressure</h3>
 Here we combine the two previous approaches to compute development pressure for 2001 and 2019.
-Tool <a href="https://grass.osgeo.org/grass80/manuals/addons/r.futures.devpressure.html">r.futures.devpressure</a>
+Tool <a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.futures.devpressure.html">r.futures.devpressure</a>
 is internally parallelized, so we can run the tool for both years concurrently and for each of them request certain number of cores.
 Notice that we need to request twice as many cores then (on a single node).
 

--- a/assignments/landscape_evol.html
+++ b/assignments/landscape_evol.html
@@ -3,7 +3,7 @@
 <p>
 Resources:
 <ul>
-    <li><a href="http://grass.osgeo.org/grass-stable/manuals/index.html">
+    <li><a href="http://grass.osgeo.org/grass-stable/manuals/">
 GRASS GIS overview and manual</a>
     <li><a href="http://www.grassbook.org/">GRASS book</a>
     <li><a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.landscape.evol.html">r.landscape.evol</a>

--- a/assignments/landscape_evol.html
+++ b/assignments/landscape_evol.html
@@ -3,10 +3,10 @@
 <p>
 Resources:
 <ul>
-    <li><a href="http://grass.osgeo.org/grass74/manuals/index.html">
+    <li><a href="http://grass.osgeo.org/grass-stable/manuals/index.html">
 GRASS GIS overview and manual</a>
     <li><a href="http://www.grassbook.org/">GRASS book</a>
-    <li><a href="https://grass.osgeo.org/grass74/manuals/addons/r.landscape.evol.html">r.landscape.evol</a>
+    <li><a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.landscape.evol.html">r.landscape.evol</a>
 </ul>
 
 
@@ -61,5 +61,5 @@ In Python shell run:
 >>> plt.show()
 </code></pre>
 
-Select appropriate cutoffs (see <a href="https://grass.osgeo.org/grass74/manuals/addons/r_landscape_evol_Flow_acc_vs_curvature.png">example</a>)
+Select appropriate cutoffs (see <a href="https://grass.osgeo.org/grass-stable/manuals/addons/r_landscape_evol_Flow_acc_vs_curvature.png">example</a>)
 and rerun the model and compare the results.

--- a/assignments/process_based_flow.html
+++ b/assignments/process_based_flow.html
@@ -3,7 +3,7 @@
 <p>
 Resources:
 <ul>
-    <li><a href="http://grass.osgeo.org/grass74/manuals/index.html">
+    <li><a href="http://grass.osgeo.org/grass-stable/manuals/index.html">
 GRASS GIS overview and manual</a>
     <li><a href="http://www.grassbook.org/">GRASS book</a>
         <li><a href="https://www.itzi.org/">Itzï</a>

--- a/assignments/process_based_flow.html
+++ b/assignments/process_based_flow.html
@@ -3,7 +3,7 @@
 <p>
 Resources:
 <ul>
-    <li><a href="http://grass.osgeo.org/grass-stable/manuals/index.html">
+    <li><a href="http://grass.osgeo.org/grass-stable/manuals/">
 GRASS GIS overview and manual</a>
     <li><a href="http://www.grassbook.org/">GRASS book</a>
         <li><a href="https://www.itzi.org/">Itzï</a>

--- a/assignments/simwe.html
+++ b/assignments/simwe.html
@@ -8,7 +8,7 @@ path sampling model.
 <p>
 Resources:
 <ul>
-    <li><a href="https://grass.osgeo.org/grass76/manuals/index.html">
+    <li><a href="https://grass.osgeo.org/grass76/manuals/">
 GRASS GIS overview and manual</a>
     <li><a href="http://www.grassbook.org/">GRASS book</a>
 </ul>

--- a/assignments/simwe.html
+++ b/assignments/simwe.html
@@ -27,7 +27,7 @@ instructions for the
 Start GRASS - click on GRASS icon or type<br>
 
 <pre><code>
-grass76
+grass
 </code></pre>
 
 <p>

--- a/assignments/simwe.html
+++ b/assignments/simwe.html
@@ -8,7 +8,7 @@ path sampling model.
 <p>
 Resources:
 <ul>
-    <li><a href="https://grass.osgeo.org/grass76/manuals/">
+    <li><a href="https://grass.osgeo.org/grass-stable/manuals/">
 GRASS GIS overview and manual</a>
     <li><a href="http://www.grassbook.org/">GRASS book</a>
 </ul>

--- a/assignments/water_geom_assign.html
+++ b/assignments/water_geom_assign.html
@@ -24,7 +24,7 @@ For more practice in watershed analysis see
 Start GRASS - click on GRASS icon or type<br>
 
 <pre><code>
-grass74
+grass
 </code></pre>
 
 <p>

--- a/assignments/water_geom_assign.html
+++ b/assignments/water_geom_assign.html
@@ -3,7 +3,7 @@
 <p>
 Resources:
 <ul>
-    <li><a href="http://grass.osgeo.org/grass74/manuals/index.html">
+    <li><a href="http://grass.osgeo.org/grass-stable/manuals/index.html">
 GRASS GIS overview and manual</a>
     <li><a href="http://www.grassbook.org/">GRASS book</a>
 </ul>

--- a/assignments/water_geom_assign.html
+++ b/assignments/water_geom_assign.html
@@ -3,7 +3,7 @@
 <p>
 Resources:
 <ul>
-    <li><a href="http://grass.osgeo.org/grass-stable/manuals/index.html">
+    <li><a href="http://grass.osgeo.org/grass-stable/manuals/">
 GRASS GIS overview and manual</a>
     <li><a href="http://www.grassbook.org/">GRASS book</a>
 </ul>

--- a/edit.py
+++ b/edit.py
@@ -10,7 +10,7 @@ for line in fileinput.input():
     # ignore header
     line = re.sub(
         r'<em class="module">([^<]*)</em>',
-        r'<em class="module"><a href="https://grass.osgeo.org/grass74/manuals/\1.html">\1</a></em>',
+        r'<em class="module"><a href="https://grass.osgeo.org/grass-stable/manuals/\1.html">\1</a></em>',
         line,
     )
     if block_start.search(line):

--- a/lectures/data_sim.html
+++ b/lectures/data_sim.html
@@ -370,7 +370,7 @@ combined systematic and random error
 <li>patches with spatial dependence 
 <li>patches based on perturbation and/or growth of existing patches
 <li><a href="https://besjournals.onlinelibrary.wiley.com/doi/full/10.1111/2041-210X.12827">Wegmann, M., et al. (2018). r. pi: A grass gis package for semi‐automatic spatial pattern analysis of remotely sensed land cover data. Methods in Ecology and Evolution, 9(1), 191-199.</a>
-<li><a href="https://grass.osgeo.org/grass80/manuals/addons/r.pi.html">Raster patch index module </a>
+<li><a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.pi.html">Raster patch index module </a>
 </ul>
 </section>
 

--- a/lectures/pops.html
+++ b/lectures/pops.html
@@ -225,7 +225,7 @@ Geospatial simulation steering for adaptive management. Environmental Modelling 
 <ul>
     <li><a href="https://github.com/ncsu-landscape-dynamics/PoPS">PoPS</a> (C++ library)
     <li><a href="https://github.com/ncsu-landscape-dynamics/rpops">rpops</a> R package (uses Rcpp for R C++ integration)
-    <li><a href="https://grass.osgeo.org/grass7/manuals/addons/r.pops.spread.html">r.pops.spread</a> GRASS GIS Addon in C++
+    <li><a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.pops.spread.html">r.pops.spread</a> GRASS GIS Addon in C++
 </ul>
 <p>
 All open source, hosted on GitHub

--- a/lectures/urban_sim.html
+++ b/lectures/urban_sim.html
@@ -462,7 +462,7 @@ Information flow diagram for the set of FUTURES modules
 <p>
 <img height=350 src="img/urban/grass_futures_diagram.png">
 <p>
-<a href="https://grass.osgeo.org/grass78/manuals/addons/r.futures.html">r.futures manual</a>
+<a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.futures.html">r.futures manual</a>
 <p><small>
 Additionally, <em>r.futures.parallelpga</em> can be used instead of <em>r.futures.pga</em>.
 </small></p>

--- a/replace_string.sh
+++ b/replace_string.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [[ $# -ne 2 ]]
+  then
+    >&2 echo "Usage:"
+    >&2 echo "  $0 old new"
+    exit 1
+fi
+
+output=$(git status --porcelain)
+if [ $? -ne 0 ]; then
+    echo "git status failed. Are you in a repository?" 1>&2;
+    exit
+elif [ -n "$output" ]; then
+    echo "No replacement done." 1>&2;
+    echo "Replace would be hard to revert because of uncommitted changes." 1>&2;
+    echo "Using \"git status\" to show what is not committed or tracked." 1>&2;
+    git status
+    exit
+fi
+
+find . -type f -name "*.html" ! -path ".git/*" ! -path "build" -exec \
+    sed -i "s+$1+$2+g" {} +

--- a/resources/latex_report_template.tex
+++ b/resources/latex_report_template.tex
@@ -19,7 +19,7 @@
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\newcommand{\gmodule}[1]{\href{https://grass.osgeo.org/grass76/manuals/#1.html}{\emph{#1}}}
+\newcommand{\gmodule}[1]{\href{https://grass.osgeo.org/grass-stable/manuals/#1.html}{\emph{#1}}}
 \newcommand{\asixmodule}[1]{\emph{#1}}
 \newcommand{\asevenmodule}[1]{\emph{#1}}
 \newcommand{\module}[1]{\emph{#1}}

--- a/topics/mass_transport_sim.html
+++ b/topics/mass_transport_sim.html
@@ -31,7 +31,7 @@ Supplemental materials:
 <li><a href="https://www.geosci-model-dev.net/12/2837/2019/gmd-12-2837-2019.html">r.sim.terrain: a landscape evolution model with dynamic hydrology</a>, explores RUSLE3D, USPED, SIMWE for short term landscape evolution modeling 
 <li><a href="http://landlab.github.io/#/">LandLab</a>
 <li><a href="https://github.com/landlab/landlab/wiki/Tutorials">Landlab wiki tutorial</a>
-<li>Molinari M, Cannata M, Begueria S and Ambrosi C 2012 GIS-based Calibration of MassMov2D. Transactions in GIS, 2012, 16(2):215-231 <a href="https://grass.osgeo.org/grass74/manuals/addons/r.massmov.html">r.massmov </a>, debris flow simulation tool
+<li>Molinari M, Cannata M, Begueria S and Ambrosi C 2012 GIS-based Calibration of MassMov2D. Transactions in GIS, 2012, 16(2):215-231 (<a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.massmov.html">r.massmov</a>, debris flow simulation tool)
 </ul>
 
 <h4>Assignment part 4.A</h4>

--- a/topics/spread_sim.html
+++ b/topics/spread_sim.html
@@ -68,7 +68,7 @@ Supplemental materials:
 </ul>
 
 <h4>Assignment part 4.A</h4>
-Perform simulations of pathogen spread for various scenarios using <a href="https://grass.osgeo.org/grass7/manuals/addons/r.pops.spread.html">r.pops.spread</a>
+Perform simulations of pathogen spread for various scenarios using <a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.pops.spread.html">r.pops.spread</a>
 and calibrate the spread model using <a href="https://github.com/ncsu-landscape-dynamics/rpops">rpops</a>:
 <ul>
 <li><a href="https://grasswiki.osgeo.org/wiki/SOD_Spread_tutorial">r.pops.spread tutorial for Sudden Oak Death (SOD) disease</a>,


### PR DESCRIPTION
- Leave out index.html from the URLs.
- Update links from v7.8 to grass-stable.
- Update links from v7.4 to grass-stable.
- Update links from v7.6 to grass-stable.
- Update links from v8.0 to grass-stable.
- Update links from v8.2 to grass-stable.
- Update links from v7 to grass-stable.
- Replace v7.4 and v7.6 by grass-stable. in scripts and LaTeX template.
- Remove number from grass command in instructions.
- Put link to r.massmov to parentheses to distinguish it from the reference.
- Add find and replace script from 582.